### PR TITLE
Implement clear cache

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -102,7 +102,7 @@ pub struct UpdateArgs {
 
 #[derive(ClapArgs, Debug)]
 pub struct CleanArgs {
-    /// Clean cache for all file extensions (.txt, .md, ).
+    /// Clean cache for all file extensions (.txt, .md, .html).
     #[arg(short, long)]
     pub all: bool,
     /// Cache the fetched bookmarks as text, HTML or markdown file.

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -334,4 +334,16 @@ mod tests {
         let cache_map = cache.cache_map.lock().unwrap();
         assert_eq!(cache_map.keys().len(), 0);
     }
+
+    #[tokio::test]
+    async fn test_clear() {
+        let cache = MockCache::new();
+        let now = Utc::now();
+        let bookmark = TargetBookmark::new("url1", now, None);
+        let content = "content";
+        cache.add(content.to_owned(), &bookmark).await.unwrap();
+        cache.clear().unwrap();
+        let cache_map = cache.cache_map.lock().unwrap();
+        assert_eq!(cache_map.keys().len(), 0);
+    }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -76,7 +76,7 @@ pub trait Caching {
     async fn remove_all(&self, bookmarks: &TargetBookmarks) -> Result<(), anyhow::Error>;
 
     /// Clear the cache, i.e. remove all files in the cache directory.
-    async fn clear(&self) -> Result<(), anyhow::Error>;
+    fn clear(&self) -> Result<(), anyhow::Error>;
 }
 
 /// The cache to store fetched bookmarks.
@@ -196,16 +196,16 @@ impl Caching for Cache {
         Ok(())
     }
 
-    async fn clear(&self) -> Result<(), anyhow::Error> {
-        let cache_path = self.path;
-        let entries = fs::read_dir(cache_path).await?;
+    fn clear(&self) -> Result<(), anyhow::Error> {
+        let cache_path = &self.path;
+        let entries = std::fs::read_dir(cache_path)?;
 
         for entry in entries {
             let entry = entry?;
             let file_type = entry.file_type()?;
 
             if file_type.is_file() {
-                fs::remove_file(entry.path())?;
+                std::fs::remove_file(entry.path())?;
             }
         }
         Ok(())
@@ -277,7 +277,7 @@ impl Caching for MockCache {
         Ok(())
     }
 
-    async fn clear(&self) -> Result<(), anyhow::Error> {
+    fn clear(&self) -> Result<(), anyhow::Error> {
         let mut cache_map = self.cache_map.lock().unwrap();
         cache_map.clear();
         Ok(())

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -74,6 +74,9 @@ pub trait Caching {
 
     /// Remove the content of multiple bookmarks from cache.
     async fn remove_all(&self, bookmarks: &TargetBookmarks) -> Result<(), anyhow::Error>;
+
+    /// Clear the cache, i.e. remove all files in the cache directory.
+    async fn clear(&self) -> Result<(), anyhow::Error>;
 }
 
 /// The cache to store fetched bookmarks.
@@ -192,6 +195,21 @@ impl Caching for Cache {
 
         Ok(())
     }
+
+    async fn clear(&self) -> Result<(), anyhow::Error> {
+        let cache_path = self.path;
+        let entries = fs::read_dir(cache_path).await?;
+
+        for entry in entries {
+            let entry = entry?;
+            let file_type = entry.file_type()?;
+
+            if file_type.is_file() {
+                fs::remove_file(entry.path())?;
+            }
+        }
+        Ok(())
+    }
 }
 
 /// The cache to store fetched bookmarks.
@@ -256,6 +274,12 @@ impl Caching for MockCache {
             cache_map.remove(&bookmark.id);
         }
 
+        Ok(())
+    }
+
+    async fn clear(&self) -> Result<(), anyhow::Error> {
+        let mut cache_map = self.cache_map.lock().unwrap();
+        cache_map.clear();
         Ok(())
     }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -198,16 +198,7 @@ impl Caching for Cache {
 
     fn clear(&self) -> Result<(), anyhow::Error> {
         let cache_path = &self.path;
-        let entries = std::fs::read_dir(cache_path)?;
-
-        for entry in entries {
-            let entry = entry?;
-            let file_type = entry.file_type()?;
-
-            if file_type.is_file() {
-                std::fs::remove_file(entry.path())?;
-            }
-        }
+        std::fs::remove_dir_all(cache_path)?;
         Ok(())
     }
 }

--- a/src/cmd/clean.rs
+++ b/src/cmd/clean.rs
@@ -6,7 +6,12 @@ pub async fn clean(config: &Config, args: &CleanArgs) -> Result<(), anyhow::Erro
     let bookmarks = TargetBookmarks::read(&mut target_bookmark_file)?;
     let cache_mode = CacheMode::new(&args.mode, &config.settings.cache_mode);
     let cache = Cache::new(&config.cache_path, cache_mode);
-    cache.remove_all(&bookmarks).await?;
+
+    if args.all {
+        cache.clear().await;
+    } else {
+        cache.remove_all(&bookmarks).await?;
+    }
 
     Ok(())
 }

--- a/src/cmd/clean.rs
+++ b/src/cmd/clean.rs
@@ -8,7 +8,7 @@ pub async fn clean(config: &Config, args: &CleanArgs) -> Result<(), anyhow::Erro
     let cache = Cache::new(&config.cache_path, cache_mode);
 
     if args.all {
-        cache.clear().await;
+        cache.clear()?;
     } else {
         cache.remove_all(&bookmarks).await?;
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,7 +8,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-const CONFIG_PATH: &str = "bogrep";
+const CONFIG_DIR: &str = "bogrep";
 const SETTINGS_FILE: &str = "settings.json";
 const BOOKMARKS_FILE: &str = "bookmarks.json";
 const CACHE_DIR: &str = "cache";
@@ -48,18 +48,17 @@ impl Config {
         let config_path = if let Ok(bogreg_home) = env::var("BOGREP_HOME") {
             PathBuf::from(bogreg_home)
         } else if let Some(config_path) = dirs::config_dir() {
-            config_path.join(CONFIG_PATH)
+            config_path.join(CONFIG_DIR)
         } else {
             return Err(anyhow!("HOME environment variable not set"));
         };
-        let config_path = Path::new(&config_path);
         let settings_path = config_path.join(SETTINGS_FILE);
         let target_bookmark_path = config_path.join(BOOKMARKS_FILE);
         let cache_path = config_path.join(CACHE_DIR);
 
         if !config_path.exists() {
             debug!("Create config at {}", config_path.display());
-            fs::create_dir_all(config_path).context(format!(
+            fs::create_dir_all(&config_path).context(format!(
                 "Can't create config directory: {}",
                 config_path.display()
             ))?;

--- a/tests/test_clean.rs
+++ b/tests/test_clean.rs
@@ -1,15 +1,94 @@
+mod common;
+
 use assert_cmd::Command;
+use bogrep::{json, utils, TargetBookmarks};
 use std::{
     fs::{self, File},
+    io::Write,
     path::PathBuf,
 };
 use tempfile::tempdir;
 use uuid::Uuid;
 
-#[test]
+#[tokio::test]
 #[cfg_attr(not(feature = "integration-test"), ignore)]
-fn test_clean() {
-    todo!()
+async fn test_clean() {
+    let mocks = common::start_mock_server(3).await;
+    let temp_dir = tempdir().unwrap();
+    let temp_path = temp_dir.path();
+    assert!(temp_path.exists(), "Missing path: {}", temp_path.display());
+    let source_path = temp_path.join("test_data");
+    let source = &source_path.join("bookmarks_simple.txt");
+    fs::create_dir_all(&source_path).unwrap();
+    let mut file = File::create(source).unwrap();
+
+    for url in mocks.keys() {
+        writeln!(file, "{}", url).unwrap();
+    }
+
+    println!("Execute 'bogrep config --source {}'", source.display());
+    let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+    cmd.env("BOGREP_HOME", temp_path);
+    cmd.args(["config", "--source", source.to_str().unwrap()]);
+    cmd.output().unwrap();
+
+    println!("Execute 'bogrep import'");
+    let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+    cmd.env("BOGREP_HOME", temp_path);
+    cmd.args(["import"]);
+    cmd.output().unwrap();
+
+    println!("Execute 'bogrep fetch --mode text'");
+    let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+    cmd.env("BOGREP_HOME", temp_path);
+    cmd.args(["fetch", "--mode", "text"]);
+    cmd.output().unwrap();
+
+    println!("Execute 'bogrep fetch --mode markdown'");
+    let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+    cmd.env("BOGREP_HOME", temp_path);
+    cmd.args(["fetch", "--mode", "markdown"]);
+    cmd.output().unwrap();
+
+    println!("Execute 'bogrep fetch --mode html'");
+    let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+    cmd.env("BOGREP_HOME", temp_path);
+    cmd.args(["fetch", "--mode", "html"]);
+    cmd.output().unwrap();
+
+    let bookmarks_path = temp_dir.path().join("bookmarks.json");
+    let bookmarks = utils::read_file(&bookmarks_path).unwrap();
+    let bookmarks = json::deserialize::<TargetBookmarks>(&bookmarks).unwrap();
+
+    for bookmark in &bookmarks.bookmarks {
+        let cache_path = temp_path.join(format!("cache/{}.txt", bookmark.id));
+        assert!(cache_path.exists());
+
+        let cache_path = temp_path.join(format!("cache/{}.md", bookmark.id));
+        assert!(cache_path.exists());
+
+        let cache_path = temp_path.join(format!("cache/{}.html", bookmark.id));
+        assert!(cache_path.exists());
+    }
+
+    println!("Execute 'bogrep clean'");
+    let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+    cmd.env("BOGREP_HOME", temp_path);
+    cmd.args(["clean"]);
+    let res = cmd.output();
+    assert!(res.is_ok(), "Can't execute command: {}", res.unwrap_err());
+
+    for bookmark in &bookmarks.bookmarks {
+        let cache_path = temp_path.join(format!("cache/{}.txt", bookmark.id));
+        // Text files are now deleted.
+        assert!(!cache_path.exists());
+
+        let cache_path = temp_path.join(format!("cache/{}.md", bookmark.id));
+        assert!(cache_path.exists());
+
+        let cache_path = temp_path.join(format!("cache/{}.html", bookmark.id));
+        assert!(cache_path.exists());
+    }
 }
 
 #[test]

--- a/tests/test_clean.rs
+++ b/tests/test_clean.rs
@@ -49,8 +49,8 @@ fn test_clean_all() {
     let res = cmd.output();
     assert!(res.is_ok(), "Can't execute command: {}", res.unwrap_err());
 
+    assert!(!cache_path.exists());
     assert!(!text_file_path.exists());
     assert!(!markdown_file_path.exists());
     assert!(!html_file_path.exists());
-    assert!(cache_path.exists());
 }

--- a/tests/test_clean.rs
+++ b/tests/test_clean.rs
@@ -1,0 +1,56 @@
+use assert_cmd::Command;
+use std::{
+    fs::{self, File},
+    path::PathBuf,
+};
+use tempfile::tempdir;
+use uuid::Uuid;
+
+#[test]
+#[cfg_attr(not(feature = "integration-test"), ignore)]
+fn test_clean() {
+    todo!()
+}
+
+#[test]
+#[cfg_attr(not(feature = "integration-test"), ignore)]
+fn test_clean_all() {
+    let temp_dir = tempdir().unwrap();
+    let temp_path = temp_dir.path();
+    assert!(temp_path.exists(), "Missing path: {}", temp_path.display());
+    let cache_path = temp_path.join("cache");
+    fs::create_dir(&cache_path).unwrap();
+    assert!(
+        cache_path.exists(),
+        "Missing path: {}",
+        cache_path.display()
+    );
+
+    let text_file_name = PathBuf::from(Uuid::new_v4().to_string()).with_extension("txt");
+    let markdown_file_name = PathBuf::from(Uuid::new_v4().to_string()).with_extension("md");
+    let html_file_name = PathBuf::from(Uuid::new_v4().to_string()).with_extension("html");
+
+    let text_file_path = cache_path.join(&text_file_name);
+    let markdown_file_path = cache_path.join(&markdown_file_name);
+    let html_file_path = cache_path.join(&html_file_name);
+
+    File::create(&text_file_path).unwrap();
+    File::create(&markdown_file_path).unwrap();
+    File::create(&html_file_path).unwrap();
+
+    assert!(text_file_path.exists());
+    assert!(markdown_file_path.exists());
+    assert!(html_file_path.exists());
+
+    println!("Execute 'bogrep clean --all'");
+    let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+    cmd.env("BOGREP_HOME", temp_path);
+    cmd.args(["clean", "--all"]);
+    let res = cmd.output();
+    assert!(res.is_ok(), "Can't execute command: {}", res.unwrap_err());
+
+    assert!(!text_file_path.exists());
+    assert!(!markdown_file_path.exists());
+    assert!(!html_file_path.exists());
+    assert!(cache_path.exists());
+}

--- a/tests/test_configure.rs
+++ b/tests/test_configure.rs
@@ -11,7 +11,6 @@ fn test_configure(source: &str) {
     let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
     cmd.env("BOGREP_HOME", temp_path);
     cmd.args(["config", "--source", source]);
-
     let res = cmd.output();
     assert!(res.is_ok(), "Can't execute command: {}", res.unwrap_err());
 

--- a/tests/test_fetch.rs
+++ b/tests/test_fetch.rs
@@ -48,7 +48,8 @@ async fn test_fetch() {
     let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
     cmd.env("BOGREP_HOME", temp_path);
     cmd.args(["fetch"]);
-    cmd.output().unwrap();
+    let res = cmd.output();
+    assert!(res.is_ok(), "Can't execute command: {}", res.unwrap_err());
 
     let bookmarks = common::test_bookmarks(&temp_dir);
     assert_eq!(bookmarks.bookmarks.len(), 3);


### PR DESCRIPTION
Add `--all` flag for `bogrep clean` which clears the cache for all file extensions (`.txt`, `.md`, `.html`).