### PR TITLE
Print only URLs of bookmarks with matched lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - added
   - Implement `bogrep -i <pattern>` (ignore case distinctions in patterns)
-  - Implement `bogrep -l <pattern>` (print only URLs of bookmarks with selected lines)
+  - Implement `bogrep -l <pattern>` (print only URLs of bookmarks with matched lines)
 
 ### v0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 <!-- markdownlint-disable MD041 MD034 -->
 
+### Unreleased
+
+- added
+  - Implement `bogrep -i <pattern>` (ignore case distinctions in patterns)
+  - Implement `bogrep -l <pattern>` (print only URLs of bookmarks with selected lines)
+
 ### v0.3.0
 
 - added

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Options:
   -v, --verbose...          
   -m, --mode <MODE>         Search the cached bookmarks in HTML or markdown format [possible values: html, text]
   -i, --ignore-case         Ignore case distinctions in patterns
-  -l, --files-with-matches  Print only URLs of bookmarks with selected lines
+  -l, --files-with-matches  Print only URLs of bookmarks with matched lines
   -h, --help                Print help
   -V, --version             Print version
 ```

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ bogrep "reed-solomon code"
   - [Install Bogrep from crates.io](#install-bogrep-from-cratesio)
   - [Install Bogrep from github.com](#install-bogrep-from-githubcom)
 - [Usage](#usage)
+  - [Search](#search)
 - [Getting help](#getting-help)
 - [Import bookmarks](#import-bookmarks)
   - [Firefox](#firefox)
@@ -68,6 +69,22 @@ bogrep fetch
 
 # Search your bookmarks in full-text search
 bogrep <pattern>
+```
+
+### Search
+
+``` bash
+bogrep <pattern>
+```
+
+``` properties
+Options:
+  -v, --verbose...          
+  -m, --mode <MODE>         Search the cached bookmarks in HTML or markdown format [possible values: html, text]
+  -i, --ignore-case         Ignore case distinctions in patterns
+  -l, --files-with-matches  Print only URLs of bookmarks with selected lines
+  -h, --help                Print help
+  -V, --version             Print version
 ```
 
 ## Getting help

--- a/src/args.rs
+++ b/src/args.rs
@@ -8,9 +8,15 @@ pub struct Args {
     pub pattern: Option<String>,
     #[arg(short, long, action = ArgAction::Count)]
     pub verbose: u8,
-    /// Cache the fetched bookmarks as HTML or markdown file.
+    /// Search the cached bookmarks in HTML or markdown format.
     #[arg(short, long, value_enum)]
     pub mode: Option<CacheMode>,
+    /// Ignore case distinctions in patterns.
+    #[arg(short = 'i', long)]
+    pub ignore_case: bool,
+    /// Print only URLs of bookmarks with selected lines.
+    #[arg(short = 'l', long)]
+    pub files_with_matches: bool,
     #[command(subcommand)]
     pub subcommands: Option<Subcommands>,
 }

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -1,5 +1,6 @@
 use crate::{
-    bookmark_reader::ReadTarget, cache::CacheMode, utils, Cache, Caching, Config, TargetBookmarks,
+    bookmark_reader::ReadTarget, cache::CacheMode, utils, Args, Cache, Caching, Config,
+    TargetBookmarks,
 };
 use anyhow::anyhow;
 use colored::Colorize;
@@ -13,16 +14,12 @@ use std::{
 /// Maximum number of characters per line displayed in the search result.
 const MAX_COLUMNS: usize = 1000;
 
-pub fn search(
-    pattern: String,
-    config: &Config,
-    cache_mode: Option<CacheMode>,
-) -> Result<(), anyhow::Error> {
+pub fn search(pattern: &str, config: &Config, args: &Args) -> Result<(), anyhow::Error> {
     if config.verbosity >= 1 {
-        info!("{pattern:?}");
+        info!("{:?}", pattern);
     }
 
-    let cache_mode = CacheMode::new(&cache_mode, &config.settings.cache_mode);
+    let cache_mode = CacheMode::new(&args.mode, &config.settings.cache_mode);
     let cache = Cache::new(&config.cache_path, cache_mode);
 
     let mut target_bookmarks = TargetBookmarks::default();
@@ -39,7 +36,7 @@ pub fn search(
 
 #[allow(clippy::comparison_chain)]
 fn search_bookmarks(
-    pattern: String,
+    pattern: &str,
     bookmarks: &TargetBookmarks,
     cache: &impl Caching,
 ) -> Result<(), anyhow::Error> {

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -50,7 +50,9 @@ fn search_bookmarks(
     let re = if args.ignore_case {
         format!("(?i){pattern}")
     } else {
-        format!("{pattern}")
+        {
+            pattern.to_string()
+        }
     };
     let regex = Regex::new(&re)?;
 
@@ -60,10 +62,10 @@ fn search_bookmarks(
             let matched_lines = find_matches(reader, &regex)?;
 
             if matched_lines.len() == 1 {
-                matches = matches + 1;
+                matches += 1;
                 println!("Match in bookmark: {}", bookmark.url.blue());
             } else if matched_lines.len() > 1 {
-                matches = matches + 1;
+                matches += 1;
                 println!("Matches in bookmark: {}", bookmark.url.blue());
             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,8 +26,8 @@ async fn main() -> Result<(), anyhow::Error> {
             }
             Subcommands::Clean(args) => cmd::clean(&config, &args).await?,
         }
-    } else if let Some(pattern) = args.pattern {
-        cmd::search(pattern, &config, args.mode)?;
+    } else if let Some(pattern) = &args.pattern {
+        cmd::search(pattern, &config, &args)?;
     } else {
         return Err(anyhow!("Missing search pattern: `bogrep <pattern>`"));
     }

--- a/tests/test_search.rs
+++ b/tests/test_search.rs
@@ -10,7 +10,7 @@ use tempfile::tempdir;
 
 #[tokio::test]
 #[cfg_attr(not(feature = "integration-test"), ignore)]
-async fn test_search() {
+async fn test_search_case_sensitive() {
     let mock_server = common::start_mock_server().await;
     let mocks = common::mount_mocks(&mock_server, 3).await;
     let temp_dir = tempdir().unwrap();
@@ -43,18 +43,75 @@ async fn test_search() {
     cmd.args(["fetch"]);
     cmd.output().unwrap();
 
-    println!("Execute 'bogrep \"test content 1\"'");
+    println!("Execute 'bogrep \"Test content 1\"'");
     let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
     cmd.env("BOGREP_HOME", temp_path);
-    cmd.arg("test content 1");
+    cmd.arg("Test content 1");
     cmd.assert()
         .success()
         .stdout(str::contains("Match in bookmark"))
         .stderr("");
 
-    println!("Execute 'bogrep \"test content 4\"'");
+    println!("Execute 'bogrep \"Test content 4\"'");
     let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
     cmd.env("BOGREP_HOME", temp_path);
-    cmd.arg("test content 4");
-    cmd.assert().success().stdout("").stderr("");
+    cmd.arg("Test content 4");
+    cmd.assert()
+        .success()
+        .stdout("No matches in bookmarks\n")
+        .stderr("");
+}
+
+#[tokio::test]
+#[cfg_attr(not(feature = "integration-test"), ignore)]
+async fn test_search_case_insensitive() {
+    let mock_server = common::start_mock_server().await;
+    let mocks = common::mount_mocks(&mock_server, 3).await;
+    let temp_dir = tempdir().unwrap();
+    let temp_path = temp_dir.path();
+    assert!(temp_path.exists(), "Missing path: {}", temp_path.display());
+    let source_path = temp_path.join("test_data");
+    let source = &source_path.join("bookmarks_simple.txt");
+    fs::create_dir_all(&source_path).unwrap();
+    let mut file = File::create(source).unwrap();
+
+    for url in mocks.keys() {
+        writeln!(file, "{}", url).unwrap();
+    }
+
+    println!("Execute 'bogrep config --source {}'", source.display());
+    let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+    cmd.env("BOGREP_HOME", temp_path);
+    cmd.args(["config", "--source", source.to_str().unwrap()]);
+    cmd.output().unwrap();
+
+    println!("Execute 'bogrep import'");
+    let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+    cmd.env("BOGREP_HOME", temp_path);
+    cmd.args(["import"]);
+    cmd.output().unwrap();
+
+    println!("Execute 'bogrep fetch'");
+    let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+    cmd.env("BOGREP_HOME", temp_path);
+    cmd.args(["fetch"]);
+    cmd.output().unwrap();
+
+    println!("Execute 'bogrep -i \"test content 1\"'");
+    let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+    cmd.env("BOGREP_HOME", temp_path);
+    cmd.args(["-i", "test content 1"]);
+    cmd.assert()
+        .success()
+        .stdout(str::contains("Match in bookmark"))
+        .stderr("");
+
+    println!("Execute 'bogrep -i \"test content 4\"'");
+    let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+    cmd.env("BOGREP_HOME", temp_path);
+    cmd.args(["-i", "test content 4"]);
+    cmd.assert()
+        .success()
+        .stdout("No matches in bookmarks\n")
+        .stderr("");
 }

--- a/tests/test_search.rs
+++ b/tests/test_search.rs
@@ -115,3 +115,57 @@ async fn test_search_case_insensitive() {
         .stdout("No matches in bookmarks\n")
         .stderr("");
 }
+
+#[tokio::test]
+#[cfg_attr(not(feature = "integration-test"), ignore)]
+async fn test_search_no_matched_lines() {
+    let mock_server = common::start_mock_server().await;
+    let mocks = common::mount_mocks(&mock_server, 3).await;
+    let temp_dir = tempdir().unwrap();
+    let temp_path = temp_dir.path();
+    assert!(temp_path.exists(), "Missing path: {}", temp_path.display());
+    let source_path = temp_path.join("test_data");
+    let source = &source_path.join("bookmarks_simple.txt");
+    fs::create_dir_all(&source_path).unwrap();
+    let mut file = File::create(source).unwrap();
+
+    for url in mocks.keys() {
+        writeln!(file, "{}", url).unwrap();
+    }
+
+    println!("Execute 'bogrep config --source {}'", source.display());
+    let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+    cmd.env("BOGREP_HOME", temp_path);
+    cmd.args(["config", "--source", source.to_str().unwrap()]);
+    cmd.output().unwrap();
+
+    println!("Execute 'bogrep import'");
+    let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+    cmd.env("BOGREP_HOME", temp_path);
+    cmd.args(["import"]);
+    cmd.output().unwrap();
+
+    println!("Execute 'bogrep fetch'");
+    let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+    cmd.env("BOGREP_HOME", temp_path);
+    cmd.args(["fetch"]);
+    cmd.output().unwrap();
+
+    println!("Execute 'bogrep -l \"Test content 1\"'");
+    let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+    cmd.env("BOGREP_HOME", temp_path);
+    cmd.args(["-l", "Test content 1"]);
+    cmd.assert()
+        .success()
+        .stdout(str::contains("Match in bookmark"))
+        .stderr("");
+
+    println!("Execute 'bogrep -l \"Test content 4\"'");
+    let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+    cmd.env("BOGREP_HOME", temp_path);
+    cmd.args(["-l", "Test content 4"]);
+    cmd.assert()
+        .success()
+        .stdout("No matches in bookmarks\n")
+        .stderr("");
+}

--- a/tests/test_search.rs
+++ b/tests/test_search.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use assert_cmd::Command;
-use predicates::str;
+use predicates::{boolean::PredicateBooleanExt, str};
 use std::{
     fs::{self, File},
     io::Write,
@@ -49,7 +49,11 @@ async fn test_search_case_sensitive() {
     cmd.arg("Test content 1");
     cmd.assert()
         .success()
-        .stdout(str::contains("Match in bookmark"))
+        .stdout(
+            str::contains("Match in bookmark")
+                .and(str::contains("endpoint_1"))
+                .and(str::contains("Test content 1")),
+        )
         .stderr("");
 
     println!("Execute 'bogrep \"Test content 4\"'");
@@ -103,7 +107,11 @@ async fn test_search_case_insensitive() {
     cmd.args(["-i", "test content 1"]);
     cmd.assert()
         .success()
-        .stdout(str::contains("Match in bookmark"))
+        .stdout(
+            str::contains("Match in bookmark")
+                .and(str::contains("endpoint_1"))
+                .and(str::contains("Test content 1")),
+        )
         .stderr("");
 
     println!("Execute 'bogrep -i \"test content 4\"'");
@@ -118,7 +126,7 @@ async fn test_search_case_insensitive() {
 
 #[tokio::test]
 #[cfg_attr(not(feature = "integration-test"), ignore)]
-async fn test_search_no_matched_lines() {
+async fn test_search_no_content() {
     let mock_server = common::start_mock_server().await;
     let mocks = common::mount_mocks(&mock_server, 3).await;
     let temp_dir = tempdir().unwrap();
@@ -157,7 +165,11 @@ async fn test_search_no_matched_lines() {
     cmd.args(["-l", "Test content 1"]);
     cmd.assert()
         .success()
-        .stdout(str::contains("Match in bookmark"))
+        .stdout(
+            str::contains("Match in bookmark")
+                .and(str::contains("endpoint_1"))
+                .and(str::contains("Test content 1").not()),
+        )
         .stderr("");
 
     println!("Execute 'bogrep -l \"Test content 4\"'");


### PR DESCRIPTION
Implement `bogrep -l <pattern>` (print only URLs of bookmarks with matched lines).