### PR TITLE
Enable markdown mode

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -24,6 +24,7 @@ pub enum CacheMode {
     Html,
     #[default]
     Text,
+    Markdown,
 }
 
 impl fmt::Display for CacheMode {
@@ -31,6 +32,7 @@ impl fmt::Display for CacheMode {
         let cache_mode = match &self {
             CacheMode::Html => "html",
             CacheMode::Text => "text",
+            CacheMode::Markdown => "markdown",
         };
         write!(f, "{}", cache_mode)
     }
@@ -47,6 +49,7 @@ impl CacheMode {
         match self {
             Self::Html => "html",
             Self::Text => "txt",
+            Self::Markdown => "md",
         }
     }
 
@@ -54,6 +57,7 @@ impl CacheMode {
         match self {
             Self::Html => ".html",
             Self::Text => ".txt",
+            Self::Markdown => ".md",
         }
     }
 }
@@ -176,6 +180,7 @@ impl Caching for Cache {
         let content = match self.mode {
             CacheMode::Html => html,
             CacheMode::Text => html::convert_to_text(&html, &bookmark.url)?,
+            CacheMode::Markdown => html::convert_to_markdown(&html),
         };
 
         if !cache_path.exists() {
@@ -199,6 +204,7 @@ impl Caching for Cache {
         let content = match self.mode {
             CacheMode::Html => html,
             CacheMode::Text => html::convert_to_text(&html, &bookmark.url)?,
+            CacheMode::Markdown => html::convert_to_markdown(&html),
         };
 
         let mut cache_file = utils::create_file_async(&cache_path).await?;
@@ -310,6 +316,7 @@ impl Caching for MockCache {
         let content = match self.mode {
             CacheMode::Html => html,
             CacheMode::Text => html::convert_to_text(&html, &bookmark.url)?,
+            CacheMode::Markdown => html::convert_to_markdown(&html),
         };
         cache_map.insert(bookmark.id.clone(), content.clone());
         Ok(content)
@@ -324,6 +331,7 @@ impl Caching for MockCache {
         let content = match self.mode {
             CacheMode::Html => html,
             CacheMode::Text => html::convert_to_text(&html, &bookmark.url)?,
+            CacheMode::Markdown => html::convert_to_markdown(&html),
         };
         cache_map.insert(bookmark.id.clone(), content.clone());
         Ok(content)

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -102,9 +102,11 @@ fn find_matches(reader: impl BufRead, regex: &Regex) -> Result<Vec<String>, anyh
                 end_index = line.len();
             }
 
-            let truncated_line = &line[start_index..end_index];
-
-            matched_lines.push(truncated_line.to_owned());
+            if let Some(truncated_line) = line.get(start_index..end_index) {
+                matched_lines.push(truncated_line.to_owned());
+            } else {
+                matched_lines.push(line.to_owned());
+            }
         }
     }
 


### PR DESCRIPTION
To enable markdown mode again, the following needs to be fixed:

1. panics for `bogrep <pattern> --mode markdown` (cf. https://github.com/quambene/bogrep/issues/30) :heavy_check_mark: 
1. conversion from HTML to markdown is leading to >1 GB markdown files for a few urls (while plaintext files are still a few kilobytes)