### PR TITLE
Handle cache error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   - Implement `bogrep -w <pattern>` (match only whole words)
 - changed
   - Set default for `max_idle_connections_per_host` from 100 to 10
+  - Fetch: Degrade hard failure to warning message for `BogrepError::CreateFile`
 
 ### v0.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - changed
   - Set default for `max_idle_connections_per_host` from 100 to 10
   - Fetch: Degrade hard failure to warning message for `BogrepError::CreateFile`
+    and `BogrepError::ConvertHost`
 
 ### v0.5.0
 

--- a/src/bookmark_reader/target_reader.rs
+++ b/src/bookmark_reader/target_reader.rs
@@ -12,11 +12,10 @@ where
 {
     fn read(&mut self, target_bookmarks: &mut TargetBookmarks) -> Result<(), BogrepError> {
         let mut buf = Vec::new();
-        self.read_to_end(&mut buf)
-            .map_err(|err| BogrepError::ReadFile(err))?;
+        self.read_to_end(&mut buf).map_err(BogrepError::ReadFile)?;
 
         // Rewind after reading.
-        self.rewind().map_err(|err| BogrepError::RewindFile(err))?;
+        self.rewind().map_err(BogrepError::RewindFile)?;
 
         let bookmarks = json::deserialize::<BookmarksJson>(&buf)?;
 

--- a/src/bookmark_reader/target_reader.rs
+++ b/src/bookmark_reader/target_reader.rs
@@ -13,11 +13,10 @@ where
     fn read(&mut self, target_bookmarks: &mut TargetBookmarks) -> Result<(), BogrepError> {
         let mut buf = Vec::new();
         self.read_to_end(&mut buf)
-            .map_err(|err| BogrepError::ReadFile(err.to_string()))?;
+            .map_err(|err| BogrepError::ReadFile(err))?;
 
         // Rewind after reading.
-        self.rewind()
-            .map_err(|err| BogrepError::RewindFile(err.to_string()))?;
+        self.rewind().map_err(|err| BogrepError::RewindFile(err))?;
 
         let bookmarks = json::deserialize::<BookmarksJson>(&buf)?;
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -174,7 +174,7 @@ impl Caching for Cache {
             let mut buf = String::new();
             cache_file
                 .read_to_string(&mut buf)
-                .map_err(|err| BogrepError::ReadFile(err.to_string()))?;
+                .map_err(|err| BogrepError::ReadFile(err))?;
             Ok(Some(buf))
         } else {
             Ok(None)

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -174,7 +174,7 @@ impl Caching for Cache {
             let mut buf = String::new();
             cache_file
                 .read_to_string(&mut buf)
-                .map_err(|err| BogrepError::ReadFile(err))?;
+                .map_err(BogrepError::ReadFile)?;
             Ok(Some(buf))
         } else {
             Ok(None)

--- a/src/client.rs
+++ b/src/client.rs
@@ -76,16 +76,19 @@ impl Fetch for Client {
                     if !html.is_empty() {
                         Ok(html)
                     } else {
-                        Err(BogrepError::EmptyResponse)
+                        Err(BogrepError::EmptyResponse(bookmark.url.to_owned()))
                     }
                 } else {
-                    Err(BogrepError::BinaryResponse)
+                    Err(BogrepError::BinaryResponse(bookmark.url.to_owned()))
                 }
             } else {
-                Err(BogrepError::BinaryResponse)
+                Err(BogrepError::BinaryResponse(bookmark.url.to_owned()))
             }
         } else {
-            Err(BogrepError::HttpStatus(response.status().to_string()))
+            Err(BogrepError::HttpStatus {
+                status: response.status().to_string(),
+                url: bookmark.url.to_owned(),
+            })
         }
     }
 }

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -168,6 +168,10 @@ pub async fn fetch_and_add_all(
                     debug!("{err}");
                     empty_response += 1;
                 }
+                BogrepError::ConvertHost(_) => {
+                    warn!("{err}");
+                    failed_response += 1;
+                }
                 BogrepError::CreateFile { .. } => {
                     // Write errors are expected if there are "Too many open
                     // files", so we are issuing a warning instead of returning

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -152,7 +152,7 @@ pub async fn fetch_and_add_all(
 
                     failed_response += 1;
                 }
-                BogrepError::HttpStatus(_) => {
+                BogrepError::HttpStatus { .. } => {
                     debug!("{err}");
                     failed_response += 1;
                 }
@@ -160,13 +160,20 @@ pub async fn fetch_and_add_all(
                     debug!("{err}");
                     failed_response += 1;
                 }
-                BogrepError::BinaryResponse => {
+                BogrepError::BinaryResponse(_) => {
                     debug!("{err}");
                     binary_response += 1;
                 }
-                BogrepError::EmptyResponse => {
+                BogrepError::EmptyResponse(_) => {
                     debug!("{err}");
                     empty_response += 1;
+                }
+                BogrepError::CreateFile { .. } => {
+                    // Write errors are expected if there are "Too many open
+                    // files", so we are issuing a warning instead of returning
+                    // a hard failure.
+                    warn!("{err}");
+                    failed_response += 1;
                 }
                 // We are aborting if there is an unexpected error.
                 err => {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -17,6 +17,8 @@ pub enum BogrepError {
     BinaryResponse(String),
     #[error("Can't fetch empty bookmark ({0})")]
     EmptyResponse(String),
+    #[error("Can't get host for url: {0}")]
+    ConvertHost(String),
     #[error("Can't serialize json: {0}")]
     SerializeJson(serde_json::Error),
     #[error("Can't deserialize json: {0}")]
@@ -25,8 +27,6 @@ pub enum BogrepError {
     ParseUrl(#[from] ParseError),
     #[error("Can't parse url: {0}")]
     ConvertHtml(readability::error::Error),
-    #[error("Can't get host for url: {0}")]
-    ConvertHost(String),
     #[error("Invalid utf8: {0}")]
     ConvertUtf8(#[from] FromUtf8Error),
     #[error("Can't read from HTML: {0}")]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -9,14 +9,14 @@ pub enum BogrepError {
     CreateClient(reqwest::Error),
     #[error("Can't fetch website: {0}")]
     HttpResponse(reqwest::Error),
-    #[error("Invalid status code: {0}")]
-    HttpStatus(String),
+    #[error("Invalid status code ({url}): {status}")]
+    HttpStatus { status: String, url: String },
     #[error("Can't fetch website: {0}")]
     ParseHttpResponse(reqwest::Error),
-    #[error("Can't fetch binary bookmark")]
-    BinaryResponse,
-    #[error("Can't fetch empty bookmark")]
-    EmptyResponse,
+    #[error("Can't fetch binary bookmark ({0})")]
+    BinaryResponse(String),
+    #[error("Can't fetch empty bookmark ({0})")]
+    EmptyResponse(String),
     #[error("Can't serialize json: {0}")]
     SerializeJson(serde_json::Error),
     #[error("Can't deserialize json: {0}")]
@@ -34,27 +34,27 @@ pub enum BogrepError {
     #[error("Can't serialize HTML: {0}")]
     SerializeHtml(io::Error),
     #[error("Can't create file at {path}: {err}")]
-    CreateFile { path: String, err: String },
+    CreateFile { path: String, err: io::Error },
     #[error("Can't open file at {path}: {err}")]
-    OpenFile { path: String, err: String },
+    OpenFile { path: String, err: io::Error },
     #[error("Can't remove file at {path}: {err}")]
-    RemoveFile { path: String, err: String },
+    RemoveFile { path: String, err: io::Error },
     #[error("Can't read file: {0}")]
-    ReadFile(String),
+    ReadFile(io::Error),
     #[error("Can't write to file at {path}: {err}")]
-    WriteFile { path: String, err: String },
+    WriteFile { path: String, err: io::Error },
     #[error("Can't append file at {path}: {err}")]
-    AppendFile { path: String, err: String },
+    AppendFile { path: String, err: io::Error },
     #[error("Can't rename file from {from} to {to}: {err}")]
     RenameFile {
         from: String,
         to: String,
-        err: String,
+        err: io::Error,
     },
     #[error("Can't flush file: {0}")]
     FlushFile(io::Error),
     #[error("Can't rewind file: {0}")]
-    RewindFile(String),
+    RewindFile(io::Error),
     #[error("Can't convert header to string: {0}")]
     ConvertToStr(#[from] ToStrError),
     #[error("Can't remove website ({url}) from cache: {err}")]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -14,7 +14,7 @@ pub fn read_file(path: &Path) -> Result<Vec<u8>, BogrepError> {
     let mut buffer = Vec::new();
     let mut file = open_file(path)?;
     file.read_to_end(&mut buffer)
-        .map_err(|err| BogrepError::ReadFile(err.to_string()))?;
+        .map_err(|err| BogrepError::ReadFile(err))?;
     Ok(buffer)
 }
 
@@ -25,7 +25,7 @@ pub fn read_file_to_string(path: &Path) -> Result<String, BogrepError> {
     let mut buffer = String::new();
     let mut file = open_file(path)?;
     file.read_to_string(&mut buffer)
-        .map_err(|err| BogrepError::ReadFile(err.to_string()))?;
+        .map_err(|err| BogrepError::ReadFile(err))?;
     Ok(buffer)
 }
 
@@ -37,7 +37,7 @@ pub fn write_file(path: &Path, content: String) -> Result<(), BogrepError> {
     file.write_all(content.as_bytes())
         .map_err(|err| BogrepError::WriteFile {
             path: path.to_string_lossy().to_string(),
-            err: err.to_string(),
+            err,
         })?;
     file.flush().map_err(BogrepError::FlushFile)?;
     Ok(())
@@ -52,7 +52,7 @@ pub async fn write_file_async(path: &Path, content: &[u8]) -> Result<(), BogrepE
         .await
         .map_err(|err| BogrepError::WriteFile {
             path: path.to_string_lossy().to_string(),
-            err: err.to_string(),
+            err,
         })?;
     file.flush().await.map_err(BogrepError::FlushFile)?;
     Ok(())
@@ -64,7 +64,7 @@ pub fn open_file(path: &Path) -> Result<File, BogrepError> {
     debug!("Open file at {}", path.display());
     let file = File::open(path).map_err(|err| BogrepError::OpenFile {
         path: path.to_string_lossy().to_string(),
-        err: err.to_string(),
+        err,
     })?;
     Ok(file)
 }
@@ -77,7 +77,7 @@ pub fn open_file_in_read_mode(path: &Path) -> Result<File, BogrepError> {
         .open(path)
         .map_err(|err| BogrepError::OpenFile {
             path: path.to_string_lossy().to_string(),
-            err: err.to_string(),
+            err,
         })?;
     Ok(file)
 }
@@ -91,7 +91,7 @@ pub fn open_file_in_read_write_mode(path: &Path) -> Result<File, BogrepError> {
         .open(path)
         .map_err(|err| BogrepError::OpenFile {
             path: path.to_string_lossy().to_string(),
-            err: err.to_string(),
+            err,
         })?;
     Ok(file)
 }
@@ -106,7 +106,7 @@ pub fn open_and_truncate_file(path: &Path) -> Result<File, BogrepError> {
         .open(path)
         .map_err(|err| BogrepError::OpenFile {
             path: path.to_string_lossy().to_string(),
-            err: err.to_string(),
+            err,
         })?;
     Ok(file)
 }
@@ -116,7 +116,7 @@ pub fn create_file(path: &Path) -> Result<File, BogrepError> {
     debug!("Create file at {}", path.display());
     let file = File::create(path).map_err(|err| BogrepError::CreateFile {
         path: path.to_string_lossy().to_string(),
-        err: err.to_string(),
+        err,
     })?;
     Ok(file)
 }
@@ -128,7 +128,7 @@ pub async fn create_file_async(path: &Path) -> Result<tokio::fs::File, BogrepErr
         .await
         .map_err(|err| BogrepError::CreateFile {
             path: path.to_string_lossy().to_string(),
-            err: err.to_string(),
+            err,
         })?;
     Ok(file)
 }
@@ -142,7 +142,7 @@ pub fn append_file(path: &Path) -> Result<File, BogrepError> {
         .open(path)
         .map_err(|err| BogrepError::AppendFile {
             path: path.to_string_lossy().to_string(),
-            err: err.to_string(),
+            err,
         })?;
     Ok(file)
 }
@@ -152,7 +152,7 @@ pub fn remove_file(path: &Path) -> Result<(), BogrepError> {
     debug!("Remove file at {}", path.display());
     fs::remove_file(path).map_err(|err| BogrepError::RemoveFile {
         path: path.to_string_lossy().to_string(),
-        err: err.to_string(),
+        err,
     })
 }
 
@@ -163,7 +163,7 @@ pub async fn remove_file_async(path: &Path) -> Result<(), BogrepError> {
         .await
         .map_err(|err| BogrepError::RemoveFile {
             path: path.to_string_lossy().to_string(),
-            err: err.to_string(),
+            err,
         })
 }
 
@@ -183,7 +183,7 @@ pub fn close_and_rename(from: (File, &Path), to: (File, &Path)) -> Result<(), Bo
     fs::rename(from.1, to.1).map_err(|err| BogrepError::RenameFile {
         from: from.1.to_string_lossy().to_string(),
         to: to.1.to_string_lossy().to_string(),
-        err: err.to_string(),
+        err,
     })?;
 
     Ok(())

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -14,7 +14,7 @@ pub fn read_file(path: &Path) -> Result<Vec<u8>, BogrepError> {
     let mut buffer = Vec::new();
     let mut file = open_file(path)?;
     file.read_to_end(&mut buffer)
-        .map_err(|err| BogrepError::ReadFile(err))?;
+        .map_err(BogrepError::ReadFile)?;
     Ok(buffer)
 }
 
@@ -25,7 +25,7 @@ pub fn read_file_to_string(path: &Path) -> Result<String, BogrepError> {
     let mut buffer = String::new();
     let mut file = open_file(path)?;
     file.read_to_string(&mut buffer)
-        .map_err(|err| BogrepError::ReadFile(err))?;
+        .map_err(BogrepError::ReadFile)?;
     Ok(buffer)
 }
 


### PR DESCRIPTION
Better error handling for `bogrep fetch`. Issue a warning instead of hard failure for expected errors.