### PR TITLE
Implement fixes and improvements

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -48,15 +48,15 @@ jobs:
     steps:
         - uses: actions/checkout@v4
         - uses: dtolnay/rust-toolchain@stable
-        - name: cargo test
-          run: cargo test --locked
+        - name: cargo test --lib
+          run: cargo test --lib --locked
   integration-test:
     runs-on: ubuntu-latest
     steps:
         - uses: actions/checkout@v4
         - uses: dtolnay/rust-toolchain@stable
-        - name: cargo test --test '*' --features integration-test
-          run: cargo test --locked --test '*' --features integration-test
+        - name: cargo test --test '*'
+          run: cargo test --test '*' --locked
   os-test:
     runs-on: ${{ matrix.os }}
     name: os-test / ${{ matrix.os }}
@@ -67,10 +67,10 @@ jobs:
     steps:
         - uses: actions/checkout@v4
         - uses: dtolnay/rust-toolchain@stable
-        - name: cargo test
-          run: cargo test --locked
-        - name: cargo test --test '*' --features integration-test
-          run: cargo test --locked --test '*' --features integration-test
+        - name: cargo test --lib
+          run: cargo test --lib --locked
+        - name: cargo test --test '*'
+          run: cargo test --test '*' --locked
   doc-test:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - Add benchmarks for fetching
 - changed
   - Update to rust 1.75
+  - Fix duplicate cache files for `bogrep fetch --urls`
 
 ### v0.6.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - changed
   - Update to rust 1.75
   - Fix duplicate cache files for `bogrep fetch --urls`
+- removed
+  - Remove `integration-test` feature
 
 ### v0.6.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - changed
   - Update to rust 1.75
   - Fix duplicate cache files for `bogrep fetch --urls`
+  - Fix report of processed bookmarks
 - removed
   - Remove `integration-test` feature
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - added
   - Add `action` to `TargetBookmark`
   - Add benchmarks for fetching
+  - Take ignored urls into account in `bogrep import`
 - changed
   - Update to rust 1.75
   - Fix duplicate cache files for `bogrep fetch --urls`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,6 @@ categories = ["command-line-utilities", "text-processing"]
 readme = "README.md"
 license = "Apache-2.0"
 
-[features]
-integration-test = []
-
 [[bench]]
 name = "fetch"
 harness = false

--- a/README.md
+++ b/README.md
@@ -250,12 +250,12 @@ You can configure the configuration path via the environment variable
 ## Testing
 
 ``` bash
-# Run unit tests
+# Run unit tests and integration tests
 cargo test
 
-# Run integration tests
-cargo test --test '*' --features integration-test
+# Run unit tests
+cargo test --lib
 
-# Run unit and integration tests
-cargo test --features integration-test
+# Run integration tests
+cargo test --test '*'
 ```

--- a/benches/fetch.rs
+++ b/benches/fetch.rs
@@ -1,6 +1,6 @@
 use bogrep::{
-    cmd, errors::BogrepError, html, Cache, CacheMode, Caching, Fetch, MockClient, TargetBookmark,
-    TargetBookmarks,
+    cmd, errors::BogrepError, html, Action, Cache, CacheMode, Caching, Fetch, MockClient,
+    TargetBookmark, TargetBookmarks,
 };
 use chrono::Utc;
 use criterion::{criterion_group, criterion_main, Criterion};
@@ -68,7 +68,7 @@ async fn fetch_concurrently(max_concurrent_requests: usize) {
                 None,
                 HashSet::new(),
                 HashSet::new(),
-                bogrep::Action::Fetch,
+                bogrep::Action::FetchAndReplace,
             ),
         );
     }
@@ -110,7 +110,7 @@ async fn fetch_in_parallel(max_parallel_requests: usize) {
                 None,
                 HashSet::new(),
                 HashSet::new(),
-                bogrep::Action::Fetch,
+                Action::FetchAndReplace,
             ),
         );
     }

--- a/benches/fetch.rs
+++ b/benches/fetch.rs
@@ -76,7 +76,7 @@ async fn fetch_concurrently(max_concurrent_requests: usize) {
     let mut bookmarks = TargetBookmarks::new(bookmarks);
     assert_eq!(bookmarks.len(), 10000);
 
-    cmd::fetch_and_cache_bookmarks(
+    cmd::process_bookmarks(
         &client,
         &cache,
         bookmarks.values_mut().collect(),
@@ -124,12 +124,12 @@ async fn fetch_in_parallel(max_parallel_requests: usize) {
     let client = Arc::new(client);
     let cache = Arc::new(cache);
 
-    fetch_and_cache_bookmarks_in_parallel(client, cache, &bookmarks, max_parallel_requests, true)
+    process_bookmarks_in_parallel(client, cache, &bookmarks, max_parallel_requests, true)
         .await
         .unwrap();
 }
 
-pub async fn fetch_and_cache_bookmarks_in_parallel(
+pub async fn process_bookmarks_in_parallel(
     client: Arc<impl Fetch + Send + Sync + 'static>,
     cache: Arc<impl Caching + Send + Sync + 'static>,
     bookmarks: &[Arc<Mutex<TargetBookmark>>],

--- a/src/bookmarks/mod.rs
+++ b/src/bookmarks/mod.rs
@@ -18,9 +18,9 @@ use uuid::Uuid;
 pub enum Action {
     /// Fetch and cache the bookmark, even if it is cached already. The cached
     /// content will be updated with the most recent version of the website.
-    Fetch,
+    FetchAndReplace,
     /// Fetch and cache bookmark if it is not cached yet.
-    Add,
+    FetchAndAdd,
     /// Remove bookmark from cache.
     Remove,
     /// No actions to be performed.

--- a/src/bookmarks/target_bookmarks.rs
+++ b/src/bookmarks/target_bookmarks.rs
@@ -44,6 +44,10 @@ impl TargetBookmark {
     pub fn set_action(&mut self, action: Action) {
         self.action = action;
     }
+
+    pub fn set_source(&mut self, source: SourceType) {
+        self.sources.insert(source);
+    }
 }
 
 impl From<JsonBookmark> for TargetBookmark {

--- a/src/bookmarks/target_bookmarks.rs
+++ b/src/bookmarks/target_bookmarks.rs
@@ -181,6 +181,14 @@ impl TargetBookmarks {
         }
     }
 
+    pub fn ignore_urls(&mut self, ignored_urls: &[String]) {
+        for url in ignored_urls {
+            if let Some(target_bookmark) = self.get_mut(url) {
+                target_bookmark.set_action(Action::Remove)
+            }
+        }
+    }
+
     pub fn filter_to_add<'a>(
         &self,
         source_bookmarks: &'a SourceBookmarks,
@@ -387,6 +395,55 @@ mod tests {
             Action::FetchAndAdd
         );
         assert_eq!(target_bookmarks.get(url5).unwrap().action, Action::Remove);
+    }
+
+    #[test]
+    fn test_ignore_urls() {
+        let now = Utc::now();
+        let url1 = "https://url1.com";
+        let url2 = "https://url2.com";
+        let url3 = "https://url3.com";
+        let ignored_urls = vec![url1.to_owned(), url3.to_owned()];
+        let mut target_bookmarks = TargetBookmarks::new(HashMap::from_iter([
+            (
+                url1.to_owned(),
+                TargetBookmark::new(
+                    url1,
+                    now,
+                    None,
+                    HashSet::new(),
+                    HashSet::new(),
+                    Action::None,
+                ),
+            ),
+            (
+                url2.to_owned(),
+                TargetBookmark::new(
+                    url2,
+                    now,
+                    None,
+                    HashSet::new(),
+                    HashSet::new(),
+                    Action::None,
+                ),
+            ),
+            (
+                url3.to_owned(),
+                TargetBookmark::new(
+                    url3,
+                    now,
+                    None,
+                    HashSet::new(),
+                    HashSet::new(),
+                    Action::None,
+                ),
+            ),
+        ]));
+
+        target_bookmarks.ignore_urls(&ignored_urls);
+        assert!(target_bookmarks.get(url1).unwrap().action == Action::Remove);
+        assert!(target_bookmarks.get(url2).unwrap().action == Action::None);
+        assert!(target_bookmarks.get(url3).unwrap().action == Action::Remove);
     }
 
     #[test]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -76,7 +76,6 @@ pub trait Caching {
     fn exists(&self, bookmark: &TargetBookmark) -> bool;
 
     /// Open the cached file for a bookmark.
-    // TODO: return `Result<Option<impl Read>, anyhow::Error>` (see <https://github.com/rust-lang/rust/issues/91611>).
     fn open(&self, bookmark: &TargetBookmark) -> Result<Option<impl Read>, BogrepError>;
 
     /// Get the content of a bookmark from cache.

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -85,7 +85,7 @@ pub async fn fetch_bookmarks(
         target_bookmarks.set_action(&Action::FetchAndAdd);
     }
 
-    fetch_and_cache_bookmarks(
+    process_bookmarks(
         client,
         cache,
         target_bookmarks.values_mut().collect(),
@@ -101,13 +101,17 @@ pub async fn fetch_bookmarks(
     Ok(())
 }
 
-/// Fetch all bookmarks and add them to cache.
-pub async fn fetch_and_cache_bookmarks(
+/// Process bookmarks for all actions except [`Action::None`].
+pub async fn process_bookmarks(
     client: &impl Fetch,
     cache: &impl Caching,
     bookmarks: Vec<&mut TargetBookmark>,
     max_concurrent_requests: usize,
 ) -> Result<(), BogrepError> {
+    let bookmarks = bookmarks
+        .into_iter()
+        .filter(|bookmark| bookmark.action != Action::None)
+        .collect::<Vec<_>>();
     let mut processed = 0;
     let mut cached = 0;
     let mut failed_response = 0;
@@ -318,7 +322,7 @@ mod tests {
                 .unwrap();
         }
 
-        let res = fetch_and_cache_bookmarks(
+        let res = process_bookmarks(
             &client,
             &cache,
             target_bookmarks.values_mut().collect(),
@@ -382,7 +386,7 @@ mod tests {
                 .unwrap();
         }
 
-        let res = fetch_and_cache_bookmarks(
+        let res = process_bookmarks(
             &client,
             &cache,
             target_bookmarks.values_mut().collect(),
@@ -454,7 +458,7 @@ mod tests {
             .await
             .unwrap();
 
-        let res = fetch_and_cache_bookmarks(
+        let res = process_bookmarks(
             &client,
             &cache,
             target_bookmarks.values_mut().collect(),
@@ -528,7 +532,7 @@ mod tests {
             .await
             .unwrap();
 
-        let res = fetch_and_cache_bookmarks(
+        let res = process_bookmarks(
             &client,
             &cache,
             target_bookmarks.values_mut().collect(),

--- a/src/cmd/import.rs
+++ b/src/cmd/import.rs
@@ -63,7 +63,8 @@ fn log_import(source_reader: &[SourceReader], target_bookmarks: &TargetBookmarks
         "Imported {} bookmarks from {} {source}: {}",
         target_bookmarks
             .values()
-            .filter(|bookmark| bookmark.action == Action::Fetch || bookmark.action == Action::Add)
+            .filter(|bookmark| bookmark.action == Action::FetchAndReplace
+                || bookmark.action == Action::FetchAndAdd)
             .collect::<Vec<_>>()
             .len(),
         source_reader.len(),

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -1,7 +1,7 @@
 use crate::{
     bookmark_reader::{ReadTarget, SourceReader, WriteTarget},
     cache::CacheMode,
-    cmd::fetch_and_cache_bookmarks,
+    cmd::process_bookmarks,
     utils, Action, Cache, Caching, Client, Config, Fetch, InitArgs, SourceBookmarks,
     TargetBookmarks,
 };
@@ -75,7 +75,7 @@ async fn init_bookmarks(
             .join(", ")
     );
 
-    fetch_and_cache_bookmarks(
+    process_bookmarks(
         client,
         cache,
         target_bookmarks.values_mut().collect(),

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -62,7 +62,7 @@ async fn init_bookmarks(
 
     let mut target_bookmarks = TargetBookmarks::from(source_bookmarks);
 
-    target_bookmarks.set_action(&Action::Add);
+    target_bookmarks.set_action(&Action::FetchAndAdd);
 
     println!(
         "Imported {} bookmarks from {} sources: {}",

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -11,7 +11,7 @@ mod update;
 pub use add::add;
 pub use clean::clean;
 pub use configure::configure;
-pub use fetch::{fetch, fetch_and_cache_bookmarks, fetch_diff};
+pub use fetch::{fetch, fetch_diff, process_bookmarks};
 pub use import::import;
 pub use init::init;
 pub use remove::remove;

--- a/src/cmd/update.rs
+++ b/src/cmd/update.rs
@@ -60,7 +60,7 @@ async fn update_bookmarks(
 
     target_bookmarks.update(&source_bookmarks)?;
 
-    cmd::fetch_and_cache_bookmarks(
+    cmd::process_bookmarks(
         client,
         cache,
         target_bookmarks.values_mut().collect(),

--- a/src/cmd/update.rs
+++ b/src/cmd/update.rs
@@ -108,7 +108,7 @@ mod tests {
                     last_cached: Some(now.timestamp_millis()),
                     sources: HashSet::new(),
                     cache_modes: HashSet::from_iter([CacheMode::Html]),
-                    action: Action::Add,
+                    action: Action::FetchAndAdd,
                 }),("https://www.quantamagazine.org/how-mathematical-curves-power-cryptography-20220919/".to_owned(),
                 TargetBookmark {
                     id: "25b6357e-6eda-4367-8212-84376c6efe05".to_owned(),
@@ -117,7 +117,7 @@ mod tests {
                     last_cached: Some(now.timestamp_millis()),
                     sources: HashSet::new(),
                     cache_modes: HashSet::from_iter([CacheMode::Html]),
-                    action: Action::Add,
+                    action: Action::FetchAndAdd,
                 }),
             ]),
             );
@@ -232,7 +232,7 @@ mod tests {
             last_cached: Some(now.timestamp_millis()),
             sources: HashSet::new(),
             cache_modes: HashSet::from_iter([CacheMode::Text]),
-            action: Action::Add,
+            action: Action::FetchAndAdd,
         }), ("https://www.quantamagazine.org/how-mathematical-curves-power-cryptography-20220919/".to_owned(), TargetBookmark {
             id: "25b6357e-6eda-4367-8212-84376c6efe05".to_owned(),
             url: "https://www.quantamagazine.org/how-mathematical-curves-power-cryptography-20220919/".to_owned(),
@@ -240,7 +240,7 @@ mod tests {
             last_cached: Some(now.timestamp_millis()),
             sources: HashSet::new(),
             cache_modes: HashSet::from_iter([CacheMode::Text]),
-            action: Action::Add,
+            action: Action::FetchAndAdd,
         })]));
         for url in &expected_bookmarks {
             client

--- a/tests/test_add.rs
+++ b/tests/test_add.rs
@@ -4,7 +4,6 @@ use predicates::str;
 use tempfile::tempdir;
 
 #[test]
-#[cfg_attr(not(feature = "integration-test"), ignore)]
 fn test_add() {
     let temp_dir = tempdir().unwrap();
     let temp_path = temp_dir.path();

--- a/tests/test_clean.rs
+++ b/tests/test_clean.rs
@@ -9,7 +9,6 @@ use std::{
 use tempfile::tempdir;
 
 #[tokio::test]
-#[cfg_attr(not(feature = "integration-test"), ignore)]
 async fn test_clean() {
     let mock_server = common::start_mock_server().await;
     let mocks = common::mount_mocks(&mock_server, 3).await;
@@ -79,7 +78,6 @@ async fn test_clean() {
 }
 
 #[tokio::test]
-#[cfg_attr(not(feature = "integration-test"), ignore)]
 async fn test_clean_all() {
     let mock_server = common::start_mock_server().await;
     let mocks = common::mount_mocks(&mock_server, 3).await;

--- a/tests/test_config.rs
+++ b/tests/test_config.rs
@@ -3,7 +3,6 @@ use std::env;
 use tempfile::tempdir;
 
 #[test]
-#[cfg_attr(not(feature = "integration-test"), ignore)]
 fn test_config() {
     let temp_dir = tempdir().unwrap();
     let temp_path = temp_dir.path();

--- a/tests/test_configure.rs
+++ b/tests/test_configure.rs
@@ -51,35 +51,30 @@ fn test_configure_source(source: &str) {
 }
 
 #[test]
-#[cfg_attr(not(feature = "integration-test"), ignore)]
 fn test_configure_source_simple() {
     let source = "./test_data/bookmarks_simple.txt";
     test_configure_source(source);
 }
 
 #[test]
-#[cfg_attr(not(feature = "integration-test"), ignore)]
 fn test_configure_source_firefox() {
     let source = "./test_data/bookmarks_firefox.json";
     test_configure_source(source);
 }
 
 #[test]
-#[cfg_attr(not(feature = "integration-test"), ignore)]
 fn test_configure_source_chrome() {
     let source = "./test_data/bookmarks_chromium.json";
     test_configure_source(source);
 }
 
 #[test]
-#[cfg_attr(not(feature = "integration-test"), ignore)]
 fn test_configure_source_chrome_no_extension() {
     let source = "./test_data/bookmarks_chromium_no_extension";
     test_configure_source(source);
 }
 
 #[test]
-#[cfg_attr(not(feature = "integration-test"), ignore)]
 fn test_configure_ignored_urls() {
     let temp_dir = tempdir().unwrap();
     let temp_path = temp_dir.path();

--- a/tests/test_fetch.rs
+++ b/tests/test_fetch.rs
@@ -9,7 +9,6 @@ use std::{
 use tempfile::tempdir;
 
 #[tokio::test]
-#[cfg_attr(not(feature = "integration-test"), ignore)]
 async fn test_fetch() {
     let mock_server = common::start_mock_server().await;
     let mocks = common::mount_mocks(&mock_server, 3).await;
@@ -69,7 +68,6 @@ async fn test_fetch() {
 }
 
 #[tokio::test]
-#[cfg_attr(not(feature = "integration-test"), ignore)]
 async fn test_fetch_diff() {
     let mock_server = common::start_mock_server().await;
     let mock_website_1 = common::mount_mock_scoped(&mock_server, 1, 10).await;
@@ -131,7 +129,6 @@ async fn test_fetch_diff() {
 // Test fetching if the cache directory was removed manually, leading to
 // inconsistent state as the target bookmarks are still marked as last cached.
 #[tokio::test]
-#[cfg_attr(not(feature = "integration-test"), ignore)]
 async fn test_fetch_empty_cache() {
     let mock_server = common::start_mock_server().await;
     let mocks = common::mount_mocks(&mock_server, 3).await;

--- a/tests/test_import.rs
+++ b/tests/test_import.rs
@@ -39,7 +39,6 @@ fn test_import(source: &str, temp_path: &Path) {
 }
 
 #[test]
-#[cfg_attr(not(feature = "integration-test"), ignore)]
 fn test_import_simple() {
     let source = "./test_data/bookmarks_simple.txt";
     let temp_dir = tempdir().unwrap();
@@ -50,7 +49,6 @@ fn test_import_simple() {
 }
 
 #[test]
-#[cfg_attr(not(feature = "integration-test"), ignore)]
 fn test_import_firefox() {
     let source = "./test_data/bookmarks_firefox.json";
     let temp_dir = tempdir().unwrap();
@@ -61,7 +59,6 @@ fn test_import_firefox() {
 }
 
 #[test]
-#[cfg_attr(not(feature = "integration-test"), ignore)]
 fn test_import_firefox_compressed() {
     let source = "./test_data/bookmarks_firefox.jsonlz4";
     test_utils::create_compressed_bookmarks(Path::new(source));
@@ -73,7 +70,6 @@ fn test_import_firefox_compressed() {
 }
 
 #[test]
-#[cfg_attr(not(feature = "integration-test"), ignore)]
 fn test_import_firefox_bookmark_folder_ubuntu() {
     let source_path = "./test_data/bookmarks_firefox.jsonlz4";
     test_utils::create_compressed_bookmarks(Path::new(source_path));
@@ -91,7 +87,6 @@ fn test_import_firefox_bookmark_folder_ubuntu() {
 }
 
 #[test]
-#[cfg_attr(not(feature = "integration-test"), ignore)]
 fn test_import_firefox_bookmark_folder_macos() {
     let source_path = "./test_data/bookmarks_firefox.jsonlz4";
     test_utils::create_compressed_bookmarks(Path::new(source_path));
@@ -109,7 +104,6 @@ fn test_import_firefox_bookmark_folder_macos() {
 }
 
 #[test]
-#[cfg_attr(not(feature = "integration-test"), ignore)]
 fn test_import_chrome() {
     let source = "./test_data/bookmarks_chromium.json";
     let temp_dir = tempdir().unwrap();
@@ -121,7 +115,6 @@ fn test_import_chrome() {
 
 // Test renaming of `bookmarks-lock.json` to `bookmarks.json`.
 #[test]
-#[cfg_attr(not(feature = "integration-test"), ignore)]
 fn test_import_consecutive() {
     let temp_dir = tempdir().unwrap();
     let temp_path = temp_dir.path();

--- a/tests/test_init.rs
+++ b/tests/test_init.rs
@@ -8,7 +8,6 @@ use std::{
 use tempfile::tempdir;
 
 #[tokio::test]
-#[cfg_attr(not(feature = "integration-test"), ignore)]
 async fn test_init() {
     let mock_server = common::start_mock_server().await;
     let mocks = common::mount_mocks(&mock_server, 3).await;

--- a/tests/test_remove.rs
+++ b/tests/test_remove.rs
@@ -4,7 +4,6 @@ use predicates::str;
 use tempfile::tempdir;
 
 #[test]
-#[cfg_attr(not(feature = "integration-test"), ignore)]
 fn test_remove() {
     let temp_dir = tempdir().unwrap();
     let temp_path = temp_dir.path();

--- a/tests/test_search.rs
+++ b/tests/test_search.rs
@@ -9,7 +9,6 @@ use std::{
 use tempfile::tempdir;
 
 #[tokio::test]
-#[cfg_attr(not(feature = "integration-test"), ignore)]
 async fn test_search_case_sensitive() {
     let mock_server = common::start_mock_server().await;
     let mocks = common::mount_mocks(&mock_server, 3).await;
@@ -67,7 +66,6 @@ async fn test_search_case_sensitive() {
 }
 
 #[tokio::test]
-#[cfg_attr(not(feature = "integration-test"), ignore)]
 async fn test_search_case_insensitive() {
     let mock_server = common::start_mock_server().await;
     let mocks = common::mount_mocks(&mock_server, 3).await;
@@ -125,7 +123,6 @@ async fn test_search_case_insensitive() {
 }
 
 #[tokio::test]
-#[cfg_attr(not(feature = "integration-test"), ignore)]
 async fn test_search_no_content() {
     let mock_server = common::start_mock_server().await;
     let mocks = common::mount_mocks(&mock_server, 3).await;

--- a/tests/test_update.rs
+++ b/tests/test_update.rs
@@ -8,7 +8,6 @@ use std::{
 use tempfile::tempdir;
 
 #[tokio::test]
-#[cfg_attr(not(feature = "integration-test"), ignore)]
 async fn test_update() {
     let mock_server = common::start_mock_server().await;
     let mocks = common::mount_mocks(&mock_server, 3).await;


### PR DESCRIPTION
- Fix duplicate cache files for `bogrep fetch --urls`
- Fix report of processed bookmarks
- Take ignored urls into account in `bogrep import`
- Remove `integration-test` feature